### PR TITLE
OS X 10.10 compatibility: htonll conflict

### DIFF
--- a/patches/ZOOKEEPER-2049.branch-3.4.patch
+++ b/patches/ZOOKEEPER-2049.branch-3.4.patch
@@ -1,0 +1,106 @@
+diff --git src/c/include/recordio.h src/c/include/recordio.h
+index 4e1b78e..90f458b 100644
+--- orig/src/c/include/recordio.h
++++ new/src/c/include/recordio.h
+@@ -73,7 +73,7 @@ void close_buffer_iarchive(struct iarchive **ia);
+ char *get_buffer(struct oarchive *);
+ int get_buffer_len(struct oarchive *);
+ 
+-int64_t htonll(int64_t v);
++int64_t zoo_htonll(int64_t v);
+ 
+ #ifdef __cplusplus
+ }
+diff --git src/c/src/recordio.c src/c/src/recordio.c
+index cf8a1ac..41797fb 100644
+--- orig/src/c/src/recordio.c
++++ new/src/c/src/recordio.c
+@@ -80,7 +80,7 @@ int oa_serialize_int(struct oarchive *oa, const char *tag, const int32_t *d)
+     priv->off+=sizeof(i);
+     return 0;
+ }
+-int64_t htonll(int64_t v)
++int64_t zoo_htonll(int64_t v)
+ {
+     int i = 0;
+     char *s = (char *)&v;
+@@ -98,7 +98,7 @@ int64_t htonll(int64_t v)
+ 
+ int oa_serialize_long(struct oarchive *oa, const char *tag, const int64_t *d)
+ {
+-    const int64_t i = htonll(*d);
++    const int64_t i = zoo_htonll(*d);
+     struct buff_struct *priv = oa->priv;
+     if ((priv->len - priv->off) < sizeof(i)) {
+         int rc = resize_buffer(priv, priv->len + sizeof(i));
+@@ -207,7 +207,7 @@ int ia_deserialize_long(struct iarchive *ia, const char *tag, int64_t *count)
+     }
+     memcpy(count, priv->buffer+priv->off, sizeof(*count));
+     priv->off+=sizeof(*count);
+-    v = htonll(*count); // htonll and  ntohll do the same
++    v = zoo_htonll(*count); // htonll and  ntohll do the same
+     *count = v;
+     return 0;
+ }
+diff --git src/c/src/zookeeper.c src/c/src/zookeeper.c
+index 27ecf8a..ba55d27 100644
+--- orig/src/c/src/zookeeper.c
++++ new/src/c/src/zookeeper.c
+@@ -1408,7 +1408,7 @@ static int serialize_prime_connect(struct connect_req *req, char* buffer){
+     memcpy(buffer + offset, &req->protocolVersion, sizeof(req->protocolVersion));
+     offset = offset +  sizeof(req->protocolVersion);
+ 
+-    req->lastZxidSeen = htonll(req->lastZxidSeen);
++    req->lastZxidSeen = zoo_htonll(req->lastZxidSeen);
+     memcpy(buffer + offset, &req->lastZxidSeen, sizeof(req->lastZxidSeen));
+     offset = offset +  sizeof(req->lastZxidSeen);
+ 
+@@ -1416,7 +1416,7 @@ static int serialize_prime_connect(struct connect_req *req, char* buffer){
+     memcpy(buffer + offset, &req->timeOut, sizeof(req->timeOut));
+     offset = offset +  sizeof(req->timeOut);
+ 
+-    req->sessionId = htonll(req->sessionId);
++    req->sessionId = zoo_htonll(req->sessionId);
+     memcpy(buffer + offset, &req->sessionId, sizeof(req->sessionId));
+     offset = offset +  sizeof(req->sessionId);
+ 
+@@ -1447,7 +1447,7 @@ static int serialize_prime_connect(struct connect_req *req, char* buffer){
+      memcpy(&req->sessionId, buffer + offset, sizeof(req->sessionId));
+      offset = offset +  sizeof(req->sessionId);
+ 
+-     req->sessionId = htonll(req->sessionId);
++     req->sessionId = zoo_htonll(req->sessionId);
+      memcpy(&req->passwd_len, buffer + offset, sizeof(req->passwd_len));
+      offset = offset +  sizeof(req->passwd_len);
+ 
+diff --git src/c/tests/ZKMocks.cc src/c/tests/ZKMocks.cc
+index 8916674..69bea16 100644
+--- orig/src/c/tests/ZKMocks.cc
++++ new/src/c/tests/ZKMocks.cc
+@@ -41,7 +41,7 @@ HandshakeRequest* HandshakeRequest::parse(const std::string& buf){
+     int offset=sizeof(req->protocolVersion);
+     
+     memcpy(&req->lastZxidSeen,buf.data()+offset,sizeof(req->lastZxidSeen));
+-    req->lastZxidSeen = htonll(req->lastZxidSeen);
++    req->lastZxidSeen = zoo_htonll(req->lastZxidSeen);
+     offset+=sizeof(req->lastZxidSeen);
+     
+     memcpy(&req->timeOut,buf.data()+offset,sizeof(req->timeOut));
+@@ -49,7 +49,7 @@ HandshakeRequest* HandshakeRequest::parse(const std::string& buf){
+     offset+=sizeof(req->timeOut);
+     
+     memcpy(&req->sessionId,buf.data()+offset,sizeof(req->sessionId));
+-    req->sessionId = htonll(req->sessionId);
++    req->sessionId = zoo_htonll(req->sessionId);
+     offset+=sizeof(req->sessionId);
+     
+     memcpy(&req->passwd_len,buf.data()+offset,sizeof(req->passwd_len));
+@@ -322,7 +322,7 @@ string HandshakeResponse::toString() const {
+     buf.append((char*)&tmp,sizeof(tmp));
+     tmp=htonl(timeOut);
+     buf.append((char*)&tmp,sizeof(tmp));
+-    int64_t tmp64=htonll(sessionId);
++    int64_t tmp64=zoo_htonll(sessionId);
+     buf.append((char*)&tmp64,sizeof(sessionId));
+     tmp=htonl(passwd_len);
+     buf.append((char*)&tmp,sizeof(tmp));


### PR DESCRIPTION
Fixed using a patch from https://issues.apache.org/jira/browse/ZOOKEEPER-2049
